### PR TITLE
For v1.1.0rfc3, patch series version 1

### DIFF
--- a/dfxml.xsd
+++ b/dfxml.xsd
@@ -8,7 +8,7 @@
 
   <xs:annotation>
     <xs:documentation>
-      This is the schema for Digital Forensics XML, version 1.1.0rfc2.
+      This is the schema for Digital Forensics XML, version 1.1.0rfc3.
 
       To report issues, questions, or feature requests, please either:
       * File a Github issue at this repository, seeing first if it is already filed: https://github.com/dfxml-working-group/dfxml_schema


### PR DESCRIPTION
This patch series introduces some allowances for DFXML extensibility.  The schema's other-namespace parsing requirements are set to "lax" to allow for arbitrary extensibility, in some elements.  "Strict" makes introducing and validating new namespaces quite cumbersome.  (The validation essentially creates a lattice structure of XML namespaces, awkward to implement and record.)

Accepting these changes means the first official DFXML schema will allow for extensibility of the language.  **I plan to merge these as RFC-3 unless there is an objection by Sep. 27 in the afternoon Eastern time.**

I welcome discussion or acks on this patch series; note these commits changed from the [first version](https://github.com/ajnelson/dfxml_schema/tree/archive/for_v1.1.0rfc3_seriesv0) after Sep. 20, when the [series](https://github.com/dfxml-working-group/dfxml_schema/pull/6) for RFC-2 was merged.
